### PR TITLE
Refactor imports

### DIFF
--- a/app/src/components/Header/index.tsx
+++ b/app/src/components/Header/index.tsx
@@ -1,8 +1,8 @@
 import { Button } from '@mui/material';
 import { useDispatch, useSelector } from 'react-redux';
-import { selectIsUserLoggedIn, selectUser } from '../../redux/auth/selectors';
-import SignIn from '../../features/authentication/SignIn';
-import SignUp from '../../features/authentication/SignUp';
+import { selectIsUserLoggedIn, selectUser } from 'redux/auth/selectors';
+import SignIn from 'features/authentication/SignIn';
+import SignUp from 'features/authentication/SignUp';
 import { useEffect, useState } from 'react';
 import { logoutCustomer } from 'redux/auth/actions';
 

--- a/app/src/components/MovieFilters/index.tsx
+++ b/app/src/components/MovieFilters/index.tsx
@@ -3,7 +3,7 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 import { Slider } from '@mui/material';
 import Genre from 'models/Genre';
 import * as S from './index.styles';
-import FilterLimits from '../../models/FilterLimits';
+import FilterLimits from 'models/FilterLimits';
 
 type MovieFiltersProps = {
     genres: Genre[];

--- a/app/src/config/withReduxProvider.tsx
+++ b/app/src/config/withReduxProvider.tsx
@@ -1,7 +1,7 @@
 import { Provider } from 'react-redux';
 import { PersistGate } from 'redux-persist/integration/react';
 import { persistStore } from 'redux-persist';
-import store from '../redux/store';
+import store from 'redux/store';
 
 export default function WithReduxProvider({
     children,

--- a/app/src/features/BrowseMoviesScreen/index.tsx
+++ b/app/src/features/BrowseMoviesScreen/index.tsx
@@ -1,16 +1,16 @@
 ﻿import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { filterMovies } from '../../redux/reducers/Movie';
-import { getGenres } from '../../redux/reducers/Genre';
-import { getFilterLimits } from '../../redux/reducers/FilterLimits';
+import { filterMovies } from 'redux/reducers/Movie';
+import { getGenres } from 'redux/reducers/Genre';
+import { getFilterLimits } from 'redux/reducers/FilterLimits';
 import { Backdrop, CircularProgress, Pagination } from '@mui/material';
 import { Col, Row } from 'react-bootstrap';
-import MovieCard from '../../components/MovieCard';
-import MovieFilters from '../../components/MovieFilters';
-import Movie from '../../models/Movie';
-import FilterMoviesRequest from '../../models/Movie/FilterMoviesRequest';
+import MovieCard from 'components/MovieCard';
+import MovieFilters from 'components/MovieFilters';
+import Movie from 'models/Movie';
+import FilterMoviesRequest from 'models/Movie/FilterMoviesRequest';
 import useAsyncError from 'hooks/useAsyncError';
-import * as selectors from '../../redux/selectors';
+import * as selectors from 'redux/selectors';
 import * as S from './index.styles';
 
 const BrowseMoviesScreen = (): JSX.Element => {

--- a/app/src/features/authentication/SignIn/index.tsx
+++ b/app/src/features/authentication/SignIn/index.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react';
 import { Formik } from 'formik';
 import { Button } from '@mui/material';
-import ModalCheKoV from '../../../components/Modal';
-import FormInput from '../../../components/FormInput';
-import * as TRANSLATIONS from '../../../translations';
+import ModalCheKoV from 'components/Modal';
+import FormInput from 'components/FormInput';
+import * as TRANSLATIONS from 'translations';
 import { useDispatch } from 'react-redux';
-import { loginCustomer } from '../../../redux/auth/modules';
+import { loginCustomer } from 'redux/auth/modules';
 
 type Props = {
     shouldRender: boolean;

--- a/app/src/features/authentication/SignUp/index.tsx
+++ b/app/src/features/authentication/SignUp/index.tsx
@@ -1,17 +1,14 @@
 import { useState } from 'react';
 import { Formik } from 'formik';
 import { Button } from '@mui/material';
-import ModalCheKoV from '../../../components/Modal';
-import * as TRANSLATIONS from '../../../translations';
-import FormInput from '../../../components/FormInput';
+import ModalCheKoV from 'components/Modal';
+import * as TRANSLATIONS from 'translations';
+import FormInput from 'components/FormInput';
 import { useDispatch, useSelector } from 'react-redux';
-import { registerCustomer } from '../../../redux/auth/modules';
-import { MIN_PASSWORD_LENGTH } from '../../../constants';
-import { selectAuthErrors } from '../../../redux/auth/selectors';
-import {
-    PASSWORDS_DONT_MATCH,
-    PASSWORD_TOO_SHORT,
-} from '../../../translations';
+import { registerCustomer } from 'redux/auth/modules';
+import { MIN_PASSWORD_LENGTH } from 'constants/index';
+import { selectAuthErrors } from 'redux/auth/selectors';
+import { PASSWORDS_DONT_MATCH, PASSWORD_TOO_SHORT } from 'translations';
 
 type Props = {
     shouldRender: boolean;

--- a/app/src/redux/api/filterLimits/index.ts
+++ b/app/src/redux/api/filterLimits/index.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
-import FilterLimits from '../../../models/FilterLimits';
-import { GET_FILTER_LIMITS_URL } from '../../../constants/api/movies';
+import FilterLimits from 'models/FilterLimits';
+import { GET_FILTER_LIMITS_URL } from 'constants/api/movies';
 
 export const getFilterLimits = () =>
     axios.get<FilterLimits>(GET_FILTER_LIMITS_URL);

--- a/app/src/redux/api/genres/index.ts
+++ b/app/src/redux/api/genres/index.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import Genre from '../../../models/Genre';
-import { GET_GENRES_URL } from '../../../constants/api/movies';
+import Genre from 'models/Genre';
+import { GET_GENRES_URL } from 'constants/api/movies';
 
 export const getGenres = () => axios.get<Genre[]>(GET_GENRES_URL);

--- a/app/src/redux/auth/reducers/index.ts
+++ b/app/src/redux/auth/reducers/index.ts
@@ -1,5 +1,5 @@
 import { createReducer } from '@reduxjs/toolkit';
-import { LoadingStatus } from '../../../constants/common';
+import { LoadingStatus } from 'constants/common';
 import {
     loginError,
     loginFullfiled,

--- a/app/src/redux/auth/reducers/types.ts
+++ b/app/src/redux/auth/reducers/types.ts
@@ -1,4 +1,4 @@
-import { LoadingStatus } from '../../../constants/common';
+import { LoadingStatus } from 'constants/common';
 import { userType } from '../models';
 
 export const authenticationReducerName = 'authentication';

--- a/app/src/redux/reducers/FilterLimits/index.ts
+++ b/app/src/redux/reducers/FilterLimits/index.ts
@@ -1,6 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
-import { ApiSuccess } from '../../../models';
-import FilterLimits from '../../../models/FilterLimits';
+import { ApiSuccess } from 'models';
+import FilterLimits from 'models/FilterLimits';
 import * as API from '../../api';
 
 export type FilterLimitsSliceType = {

--- a/app/src/redux/reducers/Genre/index.ts
+++ b/app/src/redux/reducers/Genre/index.ts
@@ -1,6 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
-import { ApiSuccess } from '../../../models';
-import Genre from '../../../models/Genre';
+import { ApiSuccess } from 'models';
+import Genre from 'models/Genre';
 import * as API from '../../api';
 
 export type GenreSliceType = {


### PR DESCRIPTION
Now importing relative to base URL, that is instead of
```import Something from '../../../components/Something'```
you can do
```import Something from 'components/Something'```
it doesn't matter which directory you're in.

The only thing that causes a small problem is the constants folder,
```import { Something } from 'constants'```
will not work, but
```import { Something } from 'constants/index'``` 
will.

